### PR TITLE
add option to enable privileged ports

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,4 +10,5 @@ docker_rootful_enabled: false
 docker_rootful_opts: "--live-restore --icc=false --default-ulimit nproc=512:1024 --default-ulimit nofile=100:200 -H fd://"
 docker_url: "https://download.docker.com/linux/static/stable/x86_64"
 docker_user: dockeruser
+docker_allow_privileged_ports: false
 ...

--- a/tasks/pre.yml
+++ b/tasks/pre.yml
@@ -87,6 +87,18 @@
   tags:
     - sysctl
 
+- name: sysctl net.ipv4.ip_unprivileged_port_start=0
+  become: 'yes'
+  sysctl:
+    name: net.ipv4.ip_unprivileged_port_start
+    value: "0"
+    sysctl_set: 'yes'
+    state: present
+    reload: 'yes'
+  when: docker_allow_privileged_ports
+  tags:
+    - sysctl
+
 - name: load the overlay2 module
   become: 'yes'
   modprobe:


### PR DESCRIPTION
Maybe somebody wants the rootless docker daemon to be able to open privileged ports. This seemed like the most straightforward way of implementing it.