### PR TITLE
Allow to mimic the normal cli behavior of docker for docker_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ docker_rootful_opts: >
   --live-restore --icc=false --default-ulimit nproc=512:1024 --default-ulimit nofile=100:200 -H fd://
 docker_url: "https://download.docker.com/linux/static/stable/x86_64"
 docker_user: dockeruser
+docker_user_bashrc: false
 docker_allow_privileged_ports: false
 docker_allow_ping: false
 ```
@@ -90,6 +91,9 @@ If `docker_add_alias: true`, then a `docker` alias will be added to either `.bas
 or `.bash_aliases`, otherwise a shell script named `docker_rootless.sh` is
 created in the Ansible user home directory that works as a substitute to the
 `docker` command.
+
+If `docker_user_bashrc: true`, a .bashrc with completion for the docker command
+will be place inside the `docker_user` home.
 
 The `docker_allow_privileged_ports` variable configures if exposing
 [privileged ports (< 1024)](https://docs.docker.com/engine/security/rootless/#exposing-privileged-ports)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ docker_user: dockeruser
 docker_user_bashrc: false
 docker_allow_privileged_ports: false
 docker_allow_ping: false
+docker_compose: false
 ```
 
 Before using this role you first have to decide if you want to install Docker
@@ -92,8 +93,10 @@ or `.bash_aliases`, otherwise a shell script named `docker_rootless.sh` is
 created in the Ansible user home directory that works as a substitute to the
 `docker` command.
 
-If `docker_user_bashrc: true`, a .bashrc with completion for the docker command
-will be place inside the `docker_user` home.
+If `docker_compose: true`, then `docker-compose` will be installed via pip.
+
+If `docker_user_bashrc: true`, a .bashrc with completion for the docker(-compose)
+command will be place inside the `docker_user` home.
 
 The `docker_allow_privileged_ports` variable configures if exposing
 [privileged ports (< 1024)](https://docs.docker.com/engine/security/rootless/#exposing-privileged-ports)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,12 +5,14 @@ docker_add_alias: true
 docker_release: "20.10.14"
 docker_release_shasum: "7ca4aeeed86619909ae584ce3405da3766d495f98904ffbd9d859add26b83af5"
 docker_release_rootless_shasum: "d47be8ef7c10748f3815304ce3deca3939655a5c5fcabeef97a76d579b8165f4"
+docker_bash_completion_shasum: "cd9c70120bc5f7e6772b6a5350abf63099004c357814abc8a8a3689a7f2e3df0"
 docker_rootful: false
 docker_rootful_enabled: false
 docker_rootful_opts: >
   --live-restore --icc=false --default-ulimit nproc=512:1024 --default-ulimit nofile=100:200 -H fd://
 docker_url: "https://download.docker.com/linux/static/stable/x86_64"
 docker_user: dockeruser
+docker_user_bashrc: false
 docker_allow_privileged_ports: false
 docker_allow_ping: false
 ...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ docker_release: "20.10.14"
 docker_release_shasum: "7ca4aeeed86619909ae584ce3405da3766d495f98904ffbd9d859add26b83af5"
 docker_release_rootless_shasum: "d47be8ef7c10748f3815304ce3deca3939655a5c5fcabeef97a76d579b8165f4"
 docker_bash_completion_shasum: "cd9c70120bc5f7e6772b6a5350abf63099004c357814abc8a8a3689a7f2e3df0"
+docker_compose_bash_completion_shasum: "9926c945b466fad570ad574089d6a90f7d9ba452a2d6a8ba67611a664707f0de"
+
 docker_rootful: false
 docker_rootful_enabled: false
 docker_rootful_opts: >
@@ -15,4 +17,6 @@ docker_user: dockeruser
 docker_user_bashrc: false
 docker_allow_privileged_ports: false
 docker_allow_ping: false
+
+docker_compose: false
 ...

--- a/files/bash_completion
+++ b/files/bash_completion
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for bcfile in ~/.bash_completion.d/* ; do
+  [ -f "$bcfile" ] && . $bcfile
+done

--- a/tasks/bashrc.yml
+++ b/tasks/bashrc.yml
@@ -1,0 +1,44 @@
+---
+
+- name: extend docker_user bashrc config
+  ansible.builtin.blockinfile:
+    path: "{{ docker_user_info.home }}/.bashrc"
+    block: |
+      export XDG_RUNTIME_DIR="/run/user/{{ docker_user_info.uid }}"
+      export DOCKER_HOST="unix:///run/user/{{ docker_user_info.uid }}/docker.sock"
+      export PATH="{{ docker_user_info.home }}/bin:{{ docker_user_info.home }}/.local/bin:$PATH"
+
+- name: create user bash completion dir
+  ansible.builtin.file:
+    path: "{{ docker_user_info.home }}/.bash_completion.d"
+    state: directory
+    owner: "{{ docker_user }}"
+    group: "{{ docker_user }}"
+    mode: 0750
+
+- name: source user bash completion dir
+  ansible.builtin.copy:
+    src: bash_completion
+    dest: "{{ docker_user_info.home }}/.bash_completion"
+    owner: "{{ docker_user }}"
+    group: "{{ docker_user }}"
+    mode: 0750
+
+- name: install docker bash completion
+  ansible.builtin.get_url:
+    url: "https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker"
+    dest: "{{ docker_user_info.home }}/.bash_completion.d/"
+    checksum: "sha256:{{ docker_bash_completion_shasum }}"
+    owner: root
+    group: root
+    mode: 0644
+
+- name: install docker-compose bash completion
+  ansible.builtin.get_url:
+    url: "https://raw.githubusercontent.com/docker/compose/1.29.2/contrib/completion/bash/docker-compose"
+    dest: "{{ docker_user_info.home }}/.bash_completion.d/"
+    checksum: "sha256:{{ docker_compose_bash_completion_shasum }}"
+    owner: root
+    group: root
+    mode: 0644
+  when: docker_compose

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,14 @@
   ansible.builtin.include_tasks: docker_install_rootless.yml
   when: not docker_rootful
 
+- name: Ensure that docker-compose python pip package is installed
+  ansible.builtin.pip:
+    name: docker-compose
+    executable: pip3
+  become: true
+  become_user: "{{ docker_user }}"
+  when: docker_compose
+
 - name: user sudo alias
   vars:
     sudo_alias: >
@@ -77,22 +85,7 @@
     mode: 0700
   when: docker_rootful or not docker_add_alias|bool
 
-- name: install docker bash completion
-  get_url:
-    url: "https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker"
-    dest: "/etc/bash_completion.d/docker"
-    checksum: "sha256:{{ docker_bash_completion_shasum }}"
-    owner: root
-    group: root
-    mode: 0644
-  when: docker_user_bashrc
-
-- name: docker_user bashrc config
-  template:
-    src: docker_user_bashrc.j2
-    dest: "{{ docker_user_info.home }}/.bashrc"
-    owner: "{{ docker_user }}"
-    group: "{{ docker_user }}"
-    mode: 0644
+- name: deploy bash completion
+  ansible.builtin.include_tasks: bashrc.yml
   when: docker_user_bashrc
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,4 +76,23 @@
     dest: "{{ ansible_env.HOME }}/docker_rootless.sh"
     mode: 0700
   when: docker_rootful or not docker_add_alias|bool
+
+- name: install docker bash completion
+  get_url:
+    url: "https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker"
+    dest: "/etc/bash_completion.d/docker"
+    checksum: "sha256:{{ docker_bash_completion_shasum }}"
+    owner: root
+    group: root
+    mode: 0644
+  when: docker_user_bashrc
+
+- name: docker_user bashrc config
+  template:
+    src: docker_user_bashrc.j2
+    dest: "{{ docker_user_info.home }}/.bashrc"
+    owner: "{{ docker_user }}"
+    group: "{{ docker_user }}"
+    mode: 0644
+  when: docker_user_bashrc
 ...

--- a/templates/docker_user_bashrc.j2
+++ b/templates/docker_user_bashrc.j2
@@ -1,0 +1,5 @@
+export XDG_RUNTIME_DIR="/run/user/{{ docker_user_info.uid }}"
+export DOCKER_HOST="unix:///run/user/{{ docker_user_info.uid }}/docker.sock"
+export PATH="~/bin:$PATH"
+
+source /etc/profile.d/bash_completion.sh

--- a/templates/docker_user_bashrc.j2
+++ b/templates/docker_user_bashrc.j2
@@ -1,5 +1,0 @@
-export XDG_RUNTIME_DIR="/run/user/{{ docker_user_info.uid }}"
-export DOCKER_HOST="unix:///run/user/{{ docker_user_info.uid }}/docker.sock"
-export PATH="~/bin:$PATH"
-
-source /etc/profile.d/bash_completion.sh


### PR DESCRIPTION
* Add new variable `docker_user_bashrc`, default false
* If true:
  * Manually download bash-completion
  * Deploy .bashrc for docker_user

Fix #12