### PR TITLE
Allow unprivileged containers to ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ docker_rootful_opts: "--live-restore --icc=false --default-ulimit nproc=512:1024
 docker_url: "https://download.docker.com/linux/static/stable/x86_64"
 docker_user: dockeruser
 docker_allow_privileged_ports: false
+docker_allow_ping: false
 ```
 
 Before using this role you first have to decide if you want to install Docker
@@ -92,6 +93,12 @@ created in the Ansible user home directory that works as a substitute to the
 The `docker_allow_privileged_ports` variable configures if exposing
 [privileged ports (< 1024)](https://docs.docker.com/engine/security/rootless/#exposing-privileged-ports)
 is allowed.
+
+The `docker_allow_ping` variable configures if unprivileged users can open [ICMP
+echo
+sockets](https://docs.docker.com/engine/security/rootless/#routing-ping-packets).
+On some distributions, this is not allowed, and thereby containers cannot ping
+to the outside.
 
 ## Container management
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,4 +12,5 @@ docker_rootful_opts: >
 docker_url: "https://download.docker.com/linux/static/stable/x86_64"
 docker_user: dockeruser
 docker_allow_privileged_ports: false
+docker_allow_ping: false
 ...

--- a/tasks/pre.yml
+++ b/tasks/pre.yml
@@ -103,6 +103,18 @@
   tags:
     - sysctl
 
+- name: sysctl net.ipv4.ping_group_range=0 2147483647
+  become: 'yes'
+  ansible.posix.sysctl:
+    name: net.ipv4.ping_group_range
+    value: "0 2147483647"
+    sysctl_set: 'yes'
+    state: present
+    reload: 'yes'
+  when: docker_allow_ping
+  tags:
+    - sysctl
+
 - name: load the overlay module
   become: 'yes'
   community.general.modprobe:


### PR DESCRIPTION
On some systems, unprivileged users cannot open ICMP echo sockets which means they cannot run ping. That's not good because some services depend on running ping commands, e.g. to check for online status or so.

This PR adds an optional sysctl line that allows basically all users to run ping commands.

Affects at least Debian 10 and 11. I am not using other systems to check it there, so I did not limit the `when` clause to certain systems. Arch seems to allow this by default, and from what I read [Fedora](https://pagure.io/fedora-docs/release-notes/issue/376) as well. But you never know ;)